### PR TITLE
Fix after_units and exec_stop_post loops

### DIFF
--- a/container_cloud_config/templates/dockersystemd.yaml
+++ b/container_cloud_config/templates/dockersystemd.yaml
@@ -21,7 +21,7 @@
     {%- endif %}
     {% for after in after_units -%}
     After={{ after }}
-    {%- endfor %}
+    {% endfor %}
 
     [Service]
     Restart={{ restart_policy }}
@@ -34,4 +34,4 @@
     ExecStop=/usr/bin/docker stop {{ name }}
     {% for stop_post in exec_stop_post -%}
     ExecStopPost={{ stop_post }}
-    {%- endfor %}
+    {% endfor %}


### PR DESCRIPTION
Whitespace control was done incorrectly in these two loops, leading to multiple after_units and exec_stop_post to be badly rendered. No line break appeared between each item.

Example with `after_units=['systemd-journal-gatewayd.socket', 'journal-2-logentries.service']`
Before:

```
        [Unit]
        After=docker.service
        After=quay-sec-image.service
        After=systemd-journal-gatewayd.socketAfter=journal-2-logentries.service
```

After:

```
        [Unit]
        After=docker.service
        After=quay-sec-image.service
        After=systemd-journal-gatewayd.socket
        After=journal-2-logentries.service
```
